### PR TITLE
disable the install target by default

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -96,6 +96,7 @@ jobs:
         -DOpenCL_INCLUDE_DIRS=$GITHUB_WORKSPACE/external/OpenCL-Headers
         -DOpenCL_LIBRARIES=${{runner.workspace}}/build_icd_loader/libOpenCL.so
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        -DOPENCL_EXTENSION_LOADER_INSTALL=ON
         -DOPENCL_EXTENSION_LOADER_SINGLE_PLATFORM_ONLY=${{matrix.single_platform}}
         -DOPENCL_EXTENSION_LOADER_XML_PATH=https://raw.githubusercontent.com/KhronosGroup/OpenCL-Registry/master/xml/cl.xml
         $GITHUB_WORKSPACE
@@ -108,6 +109,7 @@ jobs:
         -DOpenCL_INCLUDE_DIRS=$GITHUB_WORKSPACE/external/OpenCL-Headers
         -DOpenCL_LIBRARIES="${{runner.workspace}}/build_icd_loader/$BUILD_TYPE/OpenCL.lib"
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        -DOPENCL_EXTENSION_LOADER_INSTALL=ON
         -DOPENCL_EXTENSION_LOADER_SINGLE_PLATFORM_ONLY=${{matrix.single_platform}}
         -DOPENCL_EXTENSION_LOADER_XML_PATH=https://raw.githubusercontent.com/KhronosGroup/OpenCL-Registry/master/xml/cl.xml
         $GITHUB_WORKSPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ project(OpenCLExtensionLoader
 option (BUILD_SHARED_LIBS "Build shared libs" ON)
 option (OPENCL_EXTENSION_LOADER_FORCE_STATIC_LIB "Unconditionally Build a Static Library" ON)
 option (OPENCL_EXTENSION_LOADER_SINGLE_PLATFORM_ONLY "Only Support Extensions from a Single OpenCL Platform" OFF)
-option (OPENCL_EXTENSION_LOADER_INSTALL         "Generate Installation Target" ON)
+option (OPENCL_EXTENSION_LOADER_INSTALL         "Generate Installation Target" OFF)
 option (OPENCL_EXTENSION_LOADER_INCLUDE_GL      "Include OpenGL Extension APIs" ON)
 option (OPENCL_EXTENSION_LOADER_INCLUDE_EGL     "Include EGL Extension APIs" ON)
 option (OPENCL_EXTENSION_LOADER_INCLUDE_DX9     "Include DirectX 9 Extension APIs" OFF)


### PR DESCRIPTION
## Description of Changes

With at least some versions of CMake this is generating an error without the in-flight ICD loader changes.  Disable the install target by default until this is resolved.

## Testing Done

Tested automated builds and SimpleOpenCLSamples builds.