### PR TITLE
fixes for 32-bit builds

### DIFF
--- a/scripts/call_all.c.mako
+++ b/scripts/call_all.c.mako
@@ -10,6 +10,9 @@ skipExtensions = {
     # cl_APPLE_ContextLoggingFunctions is not passed a dispatchable object so
     # we cannot generate functions for it.
     'cl_APPLE_ContextLoggingFunctions',
+    # cl_APPLE_SetMemObjectDestructor could work but there is a discrepancy
+    # in the headers for the pfn_notify function.
+    'cl_APPLE_SetMemObjectDestructor',
     }
 
 defaultValueForType = {

--- a/scripts/openclext.cpp.mako
+++ b/scripts/openclext.cpp.mako
@@ -10,6 +10,9 @@ skipExtensions = {
     # cl_APPLE_ContextLoggingFunctions is not passed a dispatchable object so
     # we cannot generate functions for it.
     'cl_APPLE_ContextLoggingFunctions',
+    # cl_APPLE_SetMemObjectDestructor could work but there is a discrepancy
+    # in the headers for the pfn_notify function.
+    'cl_APPLE_SetMemObjectDestructor',
     }
 
 GL_Extensions = {
@@ -174,6 +177,8 @@ def getCParameterStrings(params):
 #if defined(CLEXT_INCLUDE_VA_API)
 #include <CL/cl_va_api_media_sharing_intel.h>
 #endif
+
+#include <stdlib.h>
 
 #include <vector>
 

--- a/src/openclext.cpp
+++ b/src/openclext.cpp
@@ -69,6 +69,8 @@
 #include <CL/cl_va_api_media_sharing_intel.h>
 #endif
 
+#include <stdlib.h>
+
 #include <vector>
 
 static inline cl_platform_id _get_platform(cl_platform_id platform)
@@ -739,17 +741,6 @@ typedef cl_int (CL_API_CALL* clEnqueueMigrateMemObjectEXT_clextfn)(
 #pragma message("Define for cl_ext_migrate_memobject was not found!  Please update your headers.")
 #endif // defined(cl_ext_migrate_memobject)
 
-#if defined(cl_APPLE_SetMemObjectDestructor)
-
-typedef cl_int (CL_API_CALL* clSetMemObjectDestructorAPPLE_clextfn)(
-    cl_mem memobj,
-    void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
-    void* user_data);
-
-#else
-#pragma message("Define for cl_APPLE_SetMemObjectDestructor was not found!  Please update your headers.")
-#endif // defined(cl_APPLE_SetMemObjectDestructor)
-
 #if defined(cl_arm_import_memory)
 
 typedef cl_mem (CL_API_CALL* clImportMemoryARM_clextfn)(
@@ -1370,10 +1361,6 @@ struct openclext_dispatch_table {
     clEnqueueMigrateMemObjectEXT_clextfn clEnqueueMigrateMemObjectEXT;
 #endif // defined(cl_ext_migrate_memobject)
 
-#if defined(cl_APPLE_SetMemObjectDestructor)
-    clSetMemObjectDestructorAPPLE_clextfn clSetMemObjectDestructorAPPLE;
-#endif // defined(cl_APPLE_SetMemObjectDestructor)
-
 #if defined(cl_arm_import_memory)
     clImportMemoryARM_clextfn clImportMemoryARM;
 #endif // defined(cl_arm_import_memory)
@@ -1628,10 +1615,6 @@ static void _init(cl_platform_id platform, openclext_dispatch_table* dispatch_pt
 #if defined(cl_ext_migrate_memobject)
     CLEXT_GET_EXTENSION(clEnqueueMigrateMemObjectEXT);
 #endif // defined(cl_ext_migrate_memobject)
-
-#if defined(cl_APPLE_SetMemObjectDestructor)
-    CLEXT_GET_EXTENSION(clSetMemObjectDestructorAPPLE);
-#endif // defined(cl_APPLE_SetMemObjectDestructor)
 
 #if defined(cl_arm_import_memory)
     CLEXT_GET_EXTENSION(clImportMemoryARM);
@@ -3255,25 +3238,6 @@ cl_int CL_API_CALL clEnqueueMigrateMemObjectEXT(
 }
 
 #endif // defined(cl_ext_migrate_memobject)
-
-#if defined(cl_APPLE_SetMemObjectDestructor)
-
-cl_int CL_API_CALL clSetMemObjectDestructorAPPLE(
-    cl_mem memobj,
-    void (CL_CALLBACK* pfn_notify)(cl_mem memobj, void* user_data),
-    void* user_data)
-{
-    struct openclext_dispatch_table* dispatch_ptr = _get_dispatch(memobj);
-    if (dispatch_ptr == NULL || dispatch_ptr->clSetMemObjectDestructorAPPLE == NULL) {
-        return CL_INVALID_OPERATION;
-    }
-    return dispatch_ptr->clSetMemObjectDestructorAPPLE(
-        memobj,
-        pfn_notify,
-        user_data);
-}
-
-#endif // defined(cl_APPLE_SetMemObjectDestructor)
 
 #if defined(cl_arm_import_memory)
 

--- a/tests/call_all.c
+++ b/tests/call_all.c
@@ -147,10 +147,6 @@ void call_all(void)
     clEnqueueMigrateMemObjectEXT(NULL, 0, NULL, CL_MIGRATE_MEM_OBJECT_HOST_EXT, 0, NULL, NULL);
 #endif // cl_ext_migrate_memobject
 
-#ifdef cl_APPLE_SetMemObjectDestructor
-    clSetMemObjectDestructorAPPLE(NULL, NULL, NULL);
-#endif // cl_APPLE_SetMemObjectDestructor
-
 #ifdef cl_arm_import_memory
     clImportMemoryARM(NULL, CL_MEM_READ_WRITE, NULL, NULL, 0, NULL);
 #endif // cl_arm_import_memory


### PR DESCRIPTION
## Description of Changes

Fixes a few issues identified when compiling 32-bit libraries with mingw:

- Need to include stdlib.h for malloc.
- Do not generate functions for `cl_APPLE_SetMemObjectDestructor` due to a discrepancy between the headers and the XML file (see: https://github.com/KhronosGroup/OpenCL-Docs/issues/853).

## Testing Done

Built 32-bit libraries with mingw.
