### PR TITLE
use static and inline more consistently

### DIFF
--- a/scripts/openclext.cpp.mako
+++ b/scripts/openclext.cpp.mako
@@ -466,7 +466,7 @@ static size_t _num_platforms = 0;
 static openclext_dispatch_table* _dispatch_array = NULL;
 
 template<typename T>
-static openclext_dispatch_table* _get_dispatch(T object)
+static inline openclext_dispatch_table* _get_dispatch(T object)
 {
     if (_num_platforms == 0 && _dispatch_array == NULL) {
         cl_uint numPlatforms = 0;

--- a/src/openclext.cpp
+++ b/src/openclext.cpp
@@ -1794,7 +1794,7 @@ static size_t _num_platforms = 0;
 static openclext_dispatch_table* _dispatch_array = NULL;
 
 template<typename T>
-static openclext_dispatch_table* _get_dispatch(T object)
+static inline openclext_dispatch_table* _get_dispatch(T object)
 {
     if (_num_platforms == 0 && _dispatch_array == NULL) {
         cl_uint numPlatforms = 0;


### PR DESCRIPTION
## Description of Changes

Uses `inline` consistently when getting the dispatch table from an object.

## Testing Done

Tested via CI and ULTs.
