### PR TITLE
add a generated file comment and disable clang-format

### DIFF
--- a/scripts/openclext.cpp.mako
+++ b/scripts/openclext.cpp.mako
@@ -113,6 +113,13 @@ def getCParameterStrings(params):
 // SPDX-License-Identifier: MIT or Apache-2.0
 */
 
+/*
+// This file is generated from the Khronos OpenCL XML API Registry.
+*/
+
+// clang-format off
+
+
 #if defined _WIN32 || defined __CYGWIN__
     #ifdef __GNUC__
         #define CL_API_ENTRY __attribute__((dllexport))

--- a/src/openclext.cpp
+++ b/src/openclext.cpp
@@ -4,6 +4,13 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 */
 
+/*
+// This file is generated from the Khronos OpenCL XML API Registry.
+*/
+
+// clang-format off
+
+
 #if defined _WIN32 || defined __CYGWIN__
     #ifdef __GNUC__
         #define CL_API_ENTRY __attribute__((dllexport))


### PR DESCRIPTION
## Description of Changes

Adds a comment reminding that the OpenCL Extension Loader is generated.

Disables clang-format because this is a generated file.

## Testing Done

Light testing via unit tests (comment change only).
