### PR TITLE
disable clang-format in the test files also

### DIFF
--- a/scripts/call_all.c.mako
+++ b/scripts/call_all.c.mako
@@ -116,7 +116,19 @@ def getCallArgs(params):
             callstr += '???'
     return callstr
 
-%>#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+%>/*******************************************************************************
+// Copyright (c) 2021-2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+/*
+// This file is generated from the Khronos OpenCL XML API Registry.
+*/
+
+// clang-format off
+
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS

--- a/tests/call_all.c
+++ b/tests/call_all.c
@@ -1,3 +1,15 @@
+/*******************************************************************************
+// Copyright (c) 2021-2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+/*
+// This file is generated from the Khronos OpenCL XML API Registry.
+*/
+
+// clang-format off
+
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS

--- a/tests/test_extension_loader.c
+++ b/tests/test_extension_loader.c
@@ -1,3 +1,11 @@
+/*******************************************************************************
+// Copyright (c) 2021-2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+// clang-format off
+
 #include "call_all.c"
 
 int main(int argc, char** argv)

--- a/tests/test_extension_loader.cpp
+++ b/tests/test_extension_loader.cpp
@@ -1,3 +1,11 @@
+/*******************************************************************************
+// Copyright (c) 2021-2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+// clang-format off
+
 #include "call_all.c"
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Description of Changes

Disable clang-format in the test files as well.

## Testing Done

Basic unit tests (comment changes only).
