### PR TITLE
disable clang-format for one more test file

### DIFF
--- a/tests/dx_sharing_prototypes.h
+++ b/tests/dx_sharing_prototypes.h
@@ -1,3 +1,11 @@
+/*******************************************************************************
+// Copyright (c) 2021-2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+// clang-format off
+
 #ifndef DX_SHARING_PROTOTYPES_H_
 #define DX_SHARING_PROTOTYPES_H_
 


### PR DESCRIPTION
## Description of Changes

Disables clang-format for the DX sharing prototypes test file also.

## Testing Done

Basic unit testing (pure comment change).
