### PR TITLE
add support for common extensions

### DIFF
--- a/scripts/call_all.c.mako
+++ b/scripts/call_all.c.mako
@@ -53,6 +53,7 @@ defaultValueForType = {
     'cl_dx9_media_adapter_set_khr'      : 'CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR',
     'cl_dx9_media_adapter_type_khr'     : 'CL_ADAPTER_D3D9_KHR',
     'cl_external_semaphore_handle_type_khr' : '0',
+    'cl_icdl_info'                      : 'CL_ICDL_OCL_VERSION',
     'cl_image_pitch_info_qcom'          : 'CL_IMAGE_ROW_ALIGNMENT_QCOM',
     'cl_image_requirements_info_ext'    : 'CL_IMAGE_REQUIREMENTS_SIZE_EXT',
     'cl_kernel_exec_info_arm'           : 'CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM',
@@ -158,8 +159,11 @@ def getCallArgs(params):
 #include <CL/cl_va_api_media_sharing_intel.h>
 #endif
 
-// Some headers to not include function prototypes for the DX sharing extensions.
+// Some headers do not include function prototypes for the DX sharing extensions.
 #include "dx_sharing_prototypes.h"
+
+// Some headers do not include function prototypes for the loader info extension.
+#include "loader_info_prototypes.h"
 
 void call_all(void)
 {

--- a/tests/call_all.c
+++ b/tests/call_all.c
@@ -40,8 +40,11 @@
 #include <CL/cl_va_api_media_sharing_intel.h>
 #endif
 
-// Some headers to not include function prototypes for the DX sharing extensions.
+// Some headers do not include function prototypes for the DX sharing extensions.
 #include "dx_sharing_prototypes.h"
+
+// Some headers do not include function prototypes for the loader info extension.
+#include "loader_info_prototypes.h"
 
 void call_all(void)
 {
@@ -256,6 +259,10 @@ void call_all(void)
     clEnqueueAcquireVA_APIMediaSurfacesINTEL(NULL, 0, NULL, 0, NULL, NULL);
     clEnqueueReleaseVA_APIMediaSurfacesINTEL(NULL, 0, NULL, 0, NULL, NULL);
 #endif // cl_intel_va_api_media_sharing
+
+#ifdef cl_loader_info
+    clGetICDLoaderInfoOCLICD(CL_ICDL_OCL_VERSION, 0, NULL, NULL);
+#endif // cl_loader_info
 
 #ifdef cl_pocl_content_size
     clSetContentSizeBufferPoCL(NULL, NULL);

--- a/tests/loader_info_prototypes.h
+++ b/tests/loader_info_prototypes.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+// Copyright (c) 2023 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT or Apache-2.0
+*/
+
+// clang-format off
+
+#ifndef LOADER_INFO_PROTOTYPES_H_
+#define LOADER_INFO_PROTOTYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(cl_loader_info)
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clGetICDLoaderInfoOCLICD(cl_icdl_info param_name,
+                         size_t       param_value_size,
+                         void *       param_value,
+                         size_t *     param_value_size_ret);
+
+#endif // defined(cl_loader_info)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LOADER_INFO_PROTOTYPES_H_


### PR DESCRIPTION
## Description of Changes

Some new extensions like the new loader info extension are common extensions, not tied to any specific platform.  They should be queried using clGetExtensionFunctionAddress, not the per-platform clGetExtensionFunctionAddressForPlatform, and they can use a single global dispatch table rather than a per-platform dispatch table.

## Testing Done

Added unit tests, also tested via a basic tester app.
