### PR TITLE
bump the required CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Note: cmake 3.7 is needed to use OpenCL::OpenCL.
 # Older versions may work by explicitly specifying OpenCL_INCLUDE_DIRS and OpenCL_LIBRARIES.
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
## Description of Changes

The latest CI pipelines have updated to CMake 4.0, which drops support for CMake 3.5 and before.  Updating the required CMake version to 3.16 should still support older operating systems, but allow the latest CI pipelines to run.

## Testing Done

Basic build testing.
